### PR TITLE
added a warning to the register_factory method for already existing factory names

### DIFF
--- a/lib/faker_maker.rb
+++ b/lib/faker_maker.rb
@@ -34,6 +34,7 @@ module FakerMaker
   module_function
 
   def register_factory( factory )
+    warn "Factory '#{factory.name}' already registered" if factories[factory.name]
     factory.assemble
     factories[factory.name] = factory
   end

--- a/lib/faker_maker/version.rb
+++ b/lib/faker_maker/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module FakerMaker
-  VERSION = '2.1.0'
+  VERSION = '2.1.1'
 end

--- a/spec/faker_maker_spec.rb
+++ b/spec/faker_maker_spec.rb
@@ -12,6 +12,11 @@ RSpec.describe FakerMaker do
     expect( FakerMaker[factory.name] ).to eq factory
   end
 
+  it 'warns if a factory is already registered' do
+    FakerMaker.register_factory(factory)
+    expect { FakerMaker.register_factory(factory) }.to output( /Factory 'placeholder' already registered/ ).to_stderr
+  end
+
   it 'builds objects from a factory' do
     FakerMaker.register_factory(factory)
     expect( FakerMaker.build( :placeholder ) ).to be_a Placeholder


### PR DESCRIPTION
added a warning to the register_factory method which outputs to the terminal if the factory name already exists when trying to register a factory