### PR TITLE
Fix embedded factory build and chaos mode support

### DIFF
--- a/lib/faker_maker/factory.rb
+++ b/lib/faker_maker/factory.rb
@@ -237,7 +237,9 @@ module FakerMaker
 
     def assert_only_known_and_optional_attributes_for_chaos( chaos_attr_values )
       chaos_attr_values = chaos_attr_values.map(&:to_sym)
-      unknown_attrs = chaos_attr_values - attribute_names
+      unknown_attrs = chaos_attr_values - attribute_names.flat_map do |item|
+        item.is_a?(Hash) ? item.keys : item
+      end
       issue = "Can't build an instance of '#{class_name}' " \
               "setting '#{unknown_attrs.join( ', ' )}', no such attribute(s)"
       raise FakerMaker::NoSuchAttributeError, issue unless unknown_attrs.empty?
@@ -280,12 +282,15 @@ module FakerMaker
       attributes = attr
                    .embedded_factories
                    .reject { |e| e == embedded_factory }
-                   .flat_map { |f| pp f.attributes.map(&:name) }
+                   .flat_map { |f| f.attributes(include_embeddings: false).map(&:name) }
                    .then { |excl| attributes.delete_if { |k, _v| excl.include?(k) } }
 
       # The object that is being manufactured by the factory.
       # If an embedded factory name is provided, it builds the object using FakerMaker.
-      embedded_factory&.build(attributes:, chaos:)
+      # Chaos is converted to a boolean so that child factories inherit random chaos
+      # behaviour without receiving attribute names meant for the parent.
+      embedded_chaos = chaos.is_a?(Array) || chaos.is_a?(String) || chaos.is_a?(Symbol) ? true : chaos
+      embedded_factory&.build(attributes:, chaos: embedded_chaos)
     end
 
     def instantiate

--- a/lib/faker_maker/version.rb
+++ b/lib/faker_maker/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module FakerMaker
-  VERSION = '5.0.0'
+  VERSION = '5.0.1'
 end

--- a/spec/faker_maker/factory_spec.rb
+++ b/spec/faker_maker/factory_spec.rb
@@ -299,6 +299,81 @@ RSpec.describe FakerMaker::Factory do
     end
   end
 
+  describe 'embedded factories' do
+    it 'builds a factory with multiple embedded factories' do
+      first_embed = FakerMaker::Factory.new( :first_embed )
+      first_embed.attach_attribute( FakerMaker::Attribute.new( :colour, proc { 'red' } ) )
+      FakerMaker.register_factory( first_embed )
+
+      second_embed = FakerMaker::Factory.new( :second_embed )
+      second_embed.attach_attribute( FakerMaker::Attribute.new( :size, proc { 'large' } ) )
+      FakerMaker.register_factory( second_embed )
+
+      factory = FakerMaker::Factory.new( :multi_embed )
+      factory.attach_attribute( FakerMaker::Attribute.new( :name, proc { 'test' }, required: true ) )
+      factory.attach_attribute( FakerMaker::Attribute.new( :variant, nil, factory: %i[first_embed second_embed] ) )
+      FakerMaker.register_factory( factory )
+
+      expect { factory.build }.not_to raise_error
+
+      fake = factory.build
+      variant = fake.variant
+      expect( variant ).to satisfy { |v| v.respond_to?(:colour) || v.respond_to?(:size) }
+    end
+
+    it 'builds with chaos mode enabled on a factory with embedded factories' do
+      embed = FakerMaker::Factory.new( :chaos_embed )
+      embed.attach_attribute( FakerMaker::Attribute.new( :value, proc { 'embedded' } ) )
+      FakerMaker.register_factory( embed )
+
+      factory = FakerMaker::Factory.new( :chaos_parent )
+      factory.attach_attribute( FakerMaker::Attribute.new( :title, proc { 'hello' }, required: true ) )
+      factory.attach_attribute( FakerMaker::Attribute.new( :child, nil, factory: :chaos_embed ) )
+      factory.attach_attribute( FakerMaker::Attribute.new( :optional_field, proc { 'maybe' } ) )
+      FakerMaker.register_factory( factory )
+
+      expect { factory.build( chaos: true ) }.not_to raise_error
+    end
+
+    it 'allows chaos mode to target an embedded factory attribute' do
+      embed = FakerMaker::Factory.new( :target_embed )
+      embed.attach_attribute( FakerMaker::Attribute.new( :value, proc { 'embedded' } ) )
+      FakerMaker.register_factory( embed )
+
+      factory = FakerMaker::Factory.new( :target_parent )
+      factory.attach_attribute( FakerMaker::Attribute.new( :title, proc { 'hello' }, required: true ) )
+      factory.attach_attribute( FakerMaker::Attribute.new( :child, nil, factory: :target_embed ) )
+      factory.attach_attribute( FakerMaker::Attribute.new( :optional_field, proc { 'maybe' } ) )
+      FakerMaker.register_factory( factory )
+
+      expect { factory.build( chaos: [:child] ) }.not_to raise_error
+
+      fakes = []
+      10.times { fakes << factory.build( chaos: [:child] ) }
+
+      fakes.each { |fake| expect( fake.title ).to eq 'hello' }
+      fakes.each { |fake| expect( fake.optional_field ).to eq 'maybe' }
+      expect( fakes.map(&:child) ).to include nil
+    end
+
+    it 'does not pass parent chaos attribute names to child factories' do
+      embed = FakerMaker::Factory.new( :leak_embed )
+      embed.attach_attribute( FakerMaker::Attribute.new( :inner_value, proc { 'inner' }, required: true ) )
+      FakerMaker.register_factory( embed )
+
+      factory = FakerMaker::Factory.new( :leak_parent )
+      factory.attach_attribute( FakerMaker::Attribute.new( :name, proc { 'parent' }, required: true ) )
+      factory.attach_attribute( FakerMaker::Attribute.new( :child, nil, factory: :leak_embed ) )
+      factory.attach_attribute( FakerMaker::Attribute.new( :optional_thing, proc { 'optional' } ) )
+      FakerMaker.register_factory( factory )
+
+      expect { factory.build( chaos: [:optional_thing] ) }.not_to raise_error
+
+      fake = factory.build( chaos: [:optional_thing] )
+      expect( fake.child.inner_value ).to eq 'inner'
+    end
+  end
+
   describe '#instance' do
     it 'returns the instance' do
       factory = FakerMaker::Factory.new( :factory )


### PR DESCRIPTION
Bug fixes in `factory.rb` for `manufacture_from_embedded_factory` and `assert_only_known_and_optional_attributes_for_chaos` methods

---

1. Fix `NoMethodError` when building factories with multiple embedded factories

`manufacture_from_embedded_factory` called `f.attributes.map(&:name)` on embedded factories. When an embedded factory itself contains embedded factories `.attributes` returns a mix of Attribute objects and Hash objects. This caused `NoMethodError: undefined method 'name' for an instance of Hash`.

Fix: Use `f.attributes(include_embeddings: false).map(&:name)` which guarantees only Attribute objects are returned.

---

2. Fix `NoSuchAttributeError` when using chaos mode with embedded factory attributes
  
`assert_only_known_and_optional_attributes_for_chaos` didn't recognise embedded factory attribute names as valid because they are stored inside Hashes rather than as plain symbols in `attribute_names`.
  
Fix: Extract attribute names from Hashes before comparison which matches the approach in `assert_only_known_attributes_for_override`.

---

3. Fix chaos attribute names leaking to child factories
  
`manufacture_from_embedded_factory` passed the `chaos:` argument directly to embedded factory builds. When chaos was an array of attribute names (e.g. `chaos: [:child_obj]`), those parent-specific names were passed to the child factory, which then failed validation because it doesn't have attributes with those names.
  
Fix: Convert chaos to a boolean before passing to embedded factories, so children inherit random chaos behaviour without receiving attribute names that are only relevant to the parent.

---

Added RSpec test coverage of:
  
1. Building a factory with multiple embedded factories
2. Chaos mode with embedded factories
3. Chaos mode targeting an embedded factory attribute by name
4. Verifying chaos attribute names don't leak to child factories