### PR TITLE
Fix embedded factory override handling for non-hash values

### DIFF
--- a/lib/faker_maker/factory.rb
+++ b/lib/faker_maker/factory.rb
@@ -255,7 +255,7 @@ module FakerMaker
     end
 
     def value_for_attribute( instance, attr, attr_override_values, chaos: false )
-      if !attr.embedded_factories? && overridden_value?( attr, attr_override_values )
+      if overridden_value?( attr, attr_override_values ) && !attr_override_values[attr.name].is_a?( Hash )
         attr_override_values[attr.name]
       elsif attr.array?
         [].tap do |a|

--- a/lib/faker_maker/version.rb
+++ b/lib/faker_maker/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module FakerMaker
-  VERSION = '5.0.1'
+  VERSION = '5.0.2'
 end

--- a/spec/faker_maker/factory_spec.rb
+++ b/spec/faker_maker/factory_spec.rb
@@ -374,6 +374,69 @@ RSpec.describe FakerMaker::Factory do
     end
   end
 
+  describe 'overriding embedded factory attributes' do
+    it 'allows FakerMaker::OMIT to be passed as an override for an embedded factory attribute' do
+      embed = FakerMaker::Factory.new( :override_embed )
+      embed.attach_attribute( FakerMaker::Attribute.new( :street, proc { '123 High St' } ) )
+      embed.attach_attribute( FakerMaker::Attribute.new( :city, proc { 'Swansea' } ) )
+      FakerMaker.register_factory( embed )
+
+      factory = FakerMaker::Factory.new( :override_parent )
+      factory.attach_attribute( FakerMaker::Attribute.new( :name, proc { 'Alice' } ) )
+      factory.attach_attribute( FakerMaker::Attribute.new( :address, nil, factory: :override_embed ) )
+      FakerMaker.register_factory( factory )
+
+      fake = factory.build( attributes: { address: FakerMaker::OMIT } )
+      expect( fake.address ).to eq FakerMaker::OMIT
+    end
+
+    it 'omits the embedded factory attribute from JSON when overridden with FakerMaker::OMIT' do
+      embed = FakerMaker::Factory.new( :override_embed )
+      embed.attach_attribute( FakerMaker::Attribute.new( :street, proc { '123 High St' } ) )
+      embed.attach_attribute( FakerMaker::Attribute.new( :city, proc { 'Swansea' } ) )
+      FakerMaker.register_factory( embed )
+
+      factory = FakerMaker::Factory.new( :override_parent )
+      factory.attach_attribute( FakerMaker::Attribute.new( :name, proc { 'Alice' } ) )
+      factory.attach_attribute( FakerMaker::Attribute.new( :address, nil, factory: :override_embed ) )
+      FakerMaker.register_factory( factory )
+
+      fake = factory.build( attributes: { address: FakerMaker::OMIT } )
+      expect( fake.as_json ).not_to have_key 'address'
+    end
+
+    it 'allows nil to be passed as an override for an embedded factory attribute' do
+      embed = FakerMaker::Factory.new( :override_embed )
+      embed.attach_attribute( FakerMaker::Attribute.new( :street, proc { '123 High St' } ) )
+      embed.attach_attribute( FakerMaker::Attribute.new( :city, proc { 'Swansea' } ) )
+      FakerMaker.register_factory( embed )
+
+      factory = FakerMaker::Factory.new( :override_parent )
+      factory.attach_attribute( FakerMaker::Attribute.new( :name, proc { 'Alice' } ) )
+      factory.attach_attribute( FakerMaker::Attribute.new( :address, nil, factory: :override_embed ) )
+      FakerMaker.register_factory( factory )
+
+      fake = factory.build( attributes: { address: nil } )
+      expect( fake.address ).to be_nil
+    end
+
+    it 'still passes Hash overrides through to the embedded factory' do
+      embed = FakerMaker::Factory.new( :override_embed )
+      embed.attach_attribute( FakerMaker::Attribute.new( :street, proc { '123 High St' } ) )
+      embed.attach_attribute( FakerMaker::Attribute.new( :city, proc { 'Swansea' } ) )
+      FakerMaker.register_factory( embed )
+
+      factory = FakerMaker::Factory.new( :override_parent )
+      factory.attach_attribute( FakerMaker::Attribute.new( :name, proc { 'Alice' } ) )
+      factory.attach_attribute( FakerMaker::Attribute.new( :address, nil, factory: :override_embed ) )
+      FakerMaker.register_factory( factory )
+
+      fake = factory.build( attributes: { address: { street: '456 Low Rd' } } )
+      expect( fake.address.street ).to eq '456 Low Rd'
+      expect( fake.address.city ).to eq 'Swansea'
+    end
+  end
+
   describe '#instance' do
     it 'returns the instance' do
       factory = FakerMaker::Factory.new( :factory )


### PR DESCRIPTION
Fix type error when overriding an embedded factory attribute with a non-hash value
  
`value_for_attribute` checked `!attr.embedded_factories?` before checking for an override. This meant non-hash overrides (e.g. `FakerMaker::OMIT`, nil) for embedded factory attributes weren't taken into account. The method fell through to building the embedded factory which then failed with a `undefined method` error .
  
Fix: Check `overridden_value?` first, then only delegate to the embedded factory build when the override is a Hash. Non-hash overrides are now returned directly, allowing `FakerMaker::OMIT` and `nil` to work as expected for embedded attributes.